### PR TITLE
abs() -> labs()

### DIFF
--- a/src/hpttree.c
+++ b/src/hpttree.c
@@ -262,7 +262,7 @@ void buildAreaTree(s_area * area)
                 MsgCloseMsg(hmsg);
 
                 /* check time period */
-                if((tperiod) && (abs(actualTime - ttime) >= (tperiod * 24 * 60 * 60)))
+                if((tperiod) && (labs(actualTime - ttime) >= (tperiod * 24 * 60 * 60)))
                 {
                     continue;
                 }
@@ -366,7 +366,7 @@ void buildAreaTree(s_area * area)
                                       *token) == NULL && strncmp(token, "\001PATH:", 6) != 0)
                             {
                                 done++;                                                              /*
-                                                                                                        
+
                                                                                                         something's
                                                                                                         wrong
                                                                                                         */

--- a/src/toss.c
+++ b/src/toss.c
@@ -1363,7 +1363,7 @@ int processEMMsg(s_message * msg, hs_addr pktOrigAddr, int dontdocc, dword force
 
                     if(msgTime != (time_t)-1)
                     {
-                        diffTime  = abs(globalTime - msgTime);
+                        diffTime  = labs(globalTime - msgTime);
                         diffTime /= (60 * 60 * 24);          /* convert to days */
                         days      = (unsigned int)diffTime;
 


### PR DESCRIPTION
Fixes warning from clang:

"warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value"