### PR TITLE
linkTo is unsigned (dword) so cannot be less than zero

### DIFF
--- a/src/hptlink.c
+++ b/src/hptlink.c
@@ -654,7 +654,7 @@ void linkArea(s_area * area)
                 /*  Link unlinked message */
                 linkTo = (replmap[crepl->treeId - 1]).treeId;
 
-                if(linkTo > highMsg || linkTo <= 0)
+                if(linkTo > highMsg || linkTo == 0)
                 {
                     w_log(LL_CRIT, "Programming error 1 while linking linkTo=%ld", (long)linkTo);
                     closeLog();
@@ -668,7 +668,7 @@ void linkArea(s_area * area)
                     {
                         linkTo = MsgUidToMsgn(harea, (replmap[linkTo - 1]).replies[0], UID_EXACT);
 
-                        if(linkTo > highMsg || linkTo <= 0)
+                        if(linkTo > highMsg || linkTo == 0)
                         {
                             w_log(LL_CRIT,
                                   "Programming error 2 while linking linkTo=%ld",


### PR DESCRIPTION
Fixes warnings with Open Watcom:

../src/hptlink.c(657): Warning! W136: Comparison equivalent to 'unsigned == 0'
../src/hptlink.c(671): Warning! W136: Comparison equivalent to 'unsigned == 0'
