### PR TITLE
fix CMake deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 2.8...3.19)
 PROJECT(hpt C)
 set(areafix_VERSION 1.9.0)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)


### PR DESCRIPTION
"Compatibility with CMake < 2.8.12 will be removed from a future version of CMake."