### PR TITLE
remove erroneous w_dbglog() call

### DIFF
--- a/src/pktread.c
+++ b/src/pktread.c
@@ -826,8 +826,6 @@ int readMsgFromPkt(FILE * pkt, s_pktHeader * header, s_message ** message)
     }
 
 #if !defined (__DOS__) || defined (__FLAT__)
-    w_dbglog(LL_DEBUG, "readMsgFromPkt()  32bit");
-
     do
     {
         len = fgetsUntil0((UCHAR *)globalBuffer, BUFFERSIZE + 1, pkt, "\n");


### PR DESCRIPTION
This was being called in 32-bit Linux (Termux on ARM specifically) with a CMake build, clobbering the output of pktinfo (and likely hpt).

It was also used by 64-bit builds but for some reason expands to a null macro, so never actually got called.

Incidentally the code below it is confusing since I don't think HPT ever officially supported 16-bit DOS, but that's something for another day.