### PR TITLE
revert broken use of strncpy(), strncat()

### DIFF
--- a/src/seenby.c
+++ b/src/seenby.c
@@ -96,8 +96,8 @@ char * createControlText(s_seenBy seenBys[], UINT seenByCount, char * lineHeadin
         sprintf(addr2d, "%u/%u", seenBys[0].net, seenBys[0].node);
         text    = (char *)safe_malloc((size_t)size);
         text[0] = '\0';
-        strncpy(line, lineHeading, strnlen(lineHeading, size - 1));
-        strncat(line, addr2d, strnlen(addr2d, size - 1 - strlen(line)));
+        strncpy(line, lineHeading, size);
+        strncat(line, addr2d, size);
 
         for(i = 1; i < seenByCount; i++)
         {


### PR DESCRIPTION
Effectively the new code became:

strncpy(line, lineHeading, 9);

Consequently 'line' was no longer being terminated, resulting in a heap overflow
in the later call to strlen(line).

The previous code was working as intended for how strncpy() and strncat() is designed.

Bug found with AddressSanitizer in FreeBSD.